### PR TITLE
Fixing a small JS bug and adding a ☑️ functionality

### DIFF
--- a/content.js
+++ b/content.js
@@ -70,12 +70,11 @@ async function generateHTML(assets) {
 }
 
 async function addToDOM(html) {
-  let photobar = document.getElementsByClassName("css-1dbjc4n r-14lw9ot r-1tlfku8 r-t23y2h r-1phboty r-rs99b7 r-ku1wi2 r-1udh08x").item(0)
-
+  let photobar = document.getElementsByClassName("SidebarCommonModules").item(0)
   let nftbar = document.createElement('div')
+  nftbar.style['margin-top'] = '10px'
   nftbar.innerHTML = html
-
-  photobar.parentNode.insertBefore(nftbar, photobar);
+  photobar.insertBefore(nftbar, photobar.firstChild);
 }
 
 async function removeFromDOM() {

--- a/content.js
+++ b/content.js
@@ -28,8 +28,10 @@ async function displayNFTs() {
     let res = await getNFTs(wallet)
 
     let html = await generateHTML(res)
-
     await addToDOM(html)
+
+    await addBlueCheckMark(res)
+
   } else {
     try { removeFromDOM() } catch (e) { }
   }
@@ -82,4 +84,21 @@ async function removeFromDOM() {
   while(elements.length > 0){
     elements[0].parentNode.removeChild(elements[0]);
   }
+}
+
+async function addBlueCheckMark(assets) {
+  let filteredAssets = assets.filter(function(asset, index, arr){
+    return asset.asset_contract.address == "0xd7d2c20a8d49cd2b0a4980070888502a1bcb4f8c";
+  });
+
+  if (filteredAssets.length > 0) {
+    let ProfileHeader = document.getElementsByClassName('ProfileHeaderCard-name').item(0)
+    let badge = document.createElement('span', {class: 'ProfileHeaderCard-badges'})
+    badge.innerHTML = '<a href="/help/verified" class="js-tooltip" target="_blank" title="Verified account" data-placement="right" rel="noopener"><span class="Icon Icon--verified"><span class="u-hiddenVisually">Verified account</span></span></a>'
+    ProfileHeader.appendChild(badge)
+  }
+
+  console.log(filteredAssets)
+
+
 }


### PR DESCRIPTION
The JS bug was due to the fact that the app was using the dynamically generated CSS classes which will likely change on every twitter build/deploy. 

Earlier today, I stumbled upon this tweet by @vbuterin : https://twitter.com/VitalikButerin/status/1164490401765572611

It turns out that @unlockProtocol we are thinking a lot about NFT as a "membership" (we call them keys) and we quickly thought that the Twitter check mark is some kind of "membership" to a group ((as visible on OpenSea)[https://opensea.io/assets/blue-checkmark]) so we created a lock for it and people can purchase their membership (0.01Eth!). The keys (NFT) are a blue check-mark... and that reminded me of that extension!

I added the functionality that, if a twitter users owns a blue check-mark NFT, then, it should add the blue check-mark by their profile!

It's a bit of a toy obviously, but it shows a pretty good use case for NFT as keys to exclusive groups. There could be a group for people who do Ruby dev, and another one for those who support the work in a given Open Source community... etc. These NFT can then be displayed by various apps.

Oh, and yes I transferred a blue check mark your way ;)

<img width="295" alt="image" src="https://user-images.githubusercontent.com/17735/63544214-a0c67080-c4f2-11e9-9638-2be315b4ddb0.png">



